### PR TITLE
Updated to include endpoints for status data

### DIFF
--- a/src/Cms.Lib.Tests/StatusTests.cs
+++ b/src/Cms.Lib.Tests/StatusTests.cs
@@ -1,0 +1,164 @@
+﻿using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace Cms.Lib.Tests
+{
+    public class StatusTests
+    {
+        [Fact]
+        public void GetSystemStatusTest()
+        {
+            // Arrange
+
+            var requestUri = new Uri("https://localhost:445/api/v1/system/status");
+
+            SystemStatusResponse response = new SystemStatusResponse
+            {
+                SoftwareVersion = "2.5.1"
+            };
+
+            StringBuilder sb = new StringBuilder();
+
+            XmlSerializer serializer = new XmlSerializer(typeof(SystemStatusResponse));
+
+            XmlWriterSettings writerSettings = new XmlWriterSettings();
+            writerSettings.OmitXmlDeclaration = true;
+
+            XmlWriter writer = XmlWriter.Create(sb, writerSettings);
+
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+
+            serializer.Serialize(writer, response, ns);
+
+
+            var mockResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sb.ToString()) };
+            var mockHandler = new Mock<HttpClientHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message => message.RequestUri == requestUri),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(mockResponse));
+
+            HttpClient client = new HttpClient(mockHandler.Object);
+            SystemStatus systemStatus = new SystemStatus(client, "https://localhost:445");
+
+            // Act
+
+            var systemStatusResult = systemStatus.Get().Result;
+
+            // Assert
+
+            Assert.True(systemStatusResult.SoftwareVersion == "2.5.1");
+        }
+
+        [Fact]
+        public void GetSystemAlarmsTest()
+        {
+            // Arrange
+
+            var requestUri = new Uri("https://localhost:445/api/v1/system/alarms");
+
+            SystemAlarStatusResponse response = new SystemAlarStatusResponse
+            {
+                Total = "0"
+            };
+
+            StringBuilder sb = new StringBuilder();
+
+            XmlSerializer serializer = new XmlSerializer(typeof(SystemAlarStatusResponse));
+
+            XmlWriterSettings writerSettings = new XmlWriterSettings();
+            writerSettings.OmitXmlDeclaration = true;
+
+            XmlWriter writer = XmlWriter.Create(sb, writerSettings);
+
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+
+            serializer.Serialize(writer, response, ns);
+
+
+            var mockResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sb.ToString()) };
+            var mockHandler = new Mock<HttpClientHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message => message.RequestUri == requestUri),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(mockResponse));
+
+            HttpClient client = new HttpClient(mockHandler.Object);
+            SystemStatus systemStatus = new SystemStatus(client, "https://localhost:445");
+
+            // Act
+
+            var systemAlarmStatus = systemStatus.GetAlarmStatus().Result;
+
+            // Assert
+
+            Assert.True(systemAlarmStatus.Total == "0");
+        }
+
+        [Fact]
+        public void GetSystemDatabaseStatusTest()
+        {
+            // Arrange
+
+            var requestUri = new Uri("https://localhost:445/api/v1/system/database");
+
+            SystemDatabaseStatusResponse response = new SystemDatabaseStatusResponse
+            {
+                Clustered ="enabled"
+            };
+
+            StringBuilder sb = new StringBuilder();
+
+            XmlSerializer serializer = new XmlSerializer(typeof(SystemDatabaseStatusResponse));
+
+            XmlWriterSettings writerSettings = new XmlWriterSettings();
+            writerSettings.OmitXmlDeclaration = true;
+
+            XmlWriter writer = XmlWriter.Create(sb, writerSettings);
+
+            XmlSerializerNamespaces ns = new XmlSerializerNamespaces();
+            ns.Add("", "");
+
+            serializer.Serialize(writer, response, ns);
+
+
+            var mockResponse = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(sb.ToString()) };
+            var mockHandler = new Mock<HttpClientHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message => message.RequestUri == requestUri),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns(Task.FromResult(mockResponse));
+
+            HttpClient client = new HttpClient(mockHandler.Object);
+            SystemStatus systemStatus = new SystemStatus(client, "https://localhost:445");
+
+            // Act
+
+            var systemDatabaseStatus = systemStatus.GetDatabaseStatus().Result;
+
+            // Assert
+
+            Assert.True(systemDatabaseStatus.Clustered == "enabled");
+        }
+    }
+}

--- a/src/Cms.Lib/CmsServer.cs
+++ b/src/Cms.Lib/CmsServer.cs
@@ -11,6 +11,7 @@ namespace Cms.Lib
         public string ApiPass { private get; set; }
         public string CmsAddress { private get; set; }
         public IMediaLoad MediaLoad { get; private set; }
+        public ISystemStatus SystemStatus { get; private set; }
 
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly HttpClient _httpClient;
@@ -28,6 +29,7 @@ namespace Cms.Lib
             _httpClient = _httpClientFactory.NewClient(ApiUser, ApiPass);
 
             MediaLoad = new MediaLoad(_httpClient, _apiUri);
+            SystemStatus = new SystemStatus(_httpClient, _apiUri);
         }
     }
 }

--- a/src/Cms.Lib/ICmsServer.cs
+++ b/src/Cms.Lib/ICmsServer.cs
@@ -7,5 +7,6 @@ namespace Cms.Lib
     public interface ICmsServer
     {
         IMediaLoad MediaLoad { get; }
+        ISystemStatus SystemStatus { get; }
     }
 }

--- a/src/Cms.Lib/ISystemStatus.cs
+++ b/src/Cms.Lib/ISystemStatus.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace Cms.Lib
+{
+    public interface ISystemStatus
+    {
+        Task<SystemStatusResponse> Get();
+        Task<SystemAlarStatusResponse> GetAlarmStatus();
+        Task<SystemDatabaseStatusResponse> GetDatabaseStatus();
+    }
+}

--- a/src/Cms.Lib/SystemAlarm.cs
+++ b/src/Cms.Lib/SystemAlarm.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("alarm")]
+    public class SystemAlarm
+    {
+        [XmlElement("type")]
+        public string Type { get; set; }
+        [XmlElement("activeTimeSeconds")]
+        public string ActiveTimeSeconds { get; set; }
+        [XmlAttribute("id")]
+        public string Id { get; set; }
+    }
+}

--- a/src/Cms.Lib/SystemAlarmStatusResponse.cs
+++ b/src/Cms.Lib/SystemAlarmStatusResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("alarms")]
+    public class SystemAlarStatusResponse
+    {
+        [XmlElement("alarm")]
+        public List<SystemAlarm> Alarm { get; set; }
+        [XmlAttribute("total")]
+        public string Total { get; set; }
+    }
+}

--- a/src/Cms.Lib/SystemDatabaseCluster.cs
+++ b/src/Cms.Lib/SystemDatabaseCluster.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("cluster")]
+    public class SystemDatabaseCluster
+    {
+        [XmlElement("node")]
+        public List<SystemDatabaseNode> Nodes { get; set; }
+        [XmlAttribute("error")]
+        public string Error { get; set; }
+        [XmlAttribute("totalNodes")]
+        public string TotalNodes { get; set; }
+        [XmlAttribute("nodeInUse")]
+        public string NodeInUse { get; set; }
+    }
+}

--- a/src/Cms.Lib/SystemDatabaseNode.cs
+++ b/src/Cms.Lib/SystemDatabaseNode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("node")]
+    public class SystemDatabaseNode
+    {
+        [XmlAttribute("hostname")]
+        public string Hostname { get; set; }
+        [XmlAttribute("syncBehind")]
+        public string SyncBehind { get; set; }
+        [XmlAttribute("master")]
+        public string Master { get; set; }
+        [XmlAttribute("up")]
+        public string Up { get; set; }
+    }
+}

--- a/src/Cms.Lib/SystemDatabaseStatusResponse.cs
+++ b/src/Cms.Lib/SystemDatabaseStatusResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("database")]
+    public class SystemDatabaseStatusResponse
+    {
+        [XmlElement("cluster")]
+        public List<SystemDatabaseCluster> Cluster { get; set; }
+        [XmlAttribute("clustered")]
+        public string Clustered { get; set; }
+    }
+}

--- a/src/Cms.Lib/SystemStatus.cs
+++ b/src/Cms.Lib/SystemStatus.cs
@@ -1,0 +1,68 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    public class SystemStatus : ISystemStatus
+    {
+        private readonly HttpClient _httpClient;
+        private string _apiStatus = "/api/v1/system/status";
+        private string _apiAlarmStatus = "/api/v1/system/alarms";
+        private string _apiDatabaseStatus = "/api/v1/system/database";
+        public string ApiUri { get; private set; }
+
+        public SystemStatus(HttpClient client, string apiUri)
+        {
+            _httpClient = client;
+            ApiUri = apiUri;
+        }
+
+        public async Task<SystemStatusResponse> Get()
+        {
+            var stringTask = await _httpClient.GetStringAsync(ApiUri + _apiStatus);
+
+            SystemStatusResponse response = new SystemStatusResponse();
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(stringTask)))
+            {
+                var serialiser = new XmlSerializer(typeof(SystemStatusResponse));
+                response = (SystemStatusResponse)serialiser.Deserialize(stream);
+            }
+
+            return response;
+        }
+
+        public async Task<SystemAlarStatusResponse> GetAlarmStatus()
+        {
+            var stringTask = await _httpClient.GetStringAsync(ApiUri + _apiAlarmStatus);
+
+            SystemAlarStatusResponse response = new SystemAlarStatusResponse();
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(stringTask)))
+            {
+                var serialiser = new XmlSerializer(typeof(SystemAlarStatusResponse));
+                response = (SystemAlarStatusResponse)serialiser.Deserialize(stream);
+            }
+
+            return response;
+        }
+
+        public async Task<SystemDatabaseStatusResponse> GetDatabaseStatus()
+        {
+            var stringTask = await _httpClient.GetStringAsync(ApiUri + _apiDatabaseStatus);
+
+            SystemDatabaseStatusResponse response = new SystemDatabaseStatusResponse();
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(stringTask)))
+            {
+                var serialiser = new XmlSerializer(typeof(SystemDatabaseStatusResponse));
+                response = (SystemDatabaseStatusResponse)serialiser.Deserialize(stream);
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/Cms.Lib/SystemStatusResponse.cs
+++ b/src/Cms.Lib/SystemStatusResponse.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace Cms.Lib
+{
+    [Serializable, XmlRoot("status")]
+    public class SystemStatusResponse
+    {
+        [XmlElement("softwareVersion")]
+        public string SoftwareVersion { get; set; }
+        [XmlElement("uptimeSeconds")]
+        public int UptimeSeconds { get; set; }
+        [XmlElement("cdrTime")]
+        public string CdrTime { get; set; }
+        [XmlElement("activated")]
+        public bool Activated { get; set; }
+        [XmlElement("clusterEnabled")]
+        public bool ClusterEnabled { get; set; }
+        [XmlElement("cdrCorrelatorIndex")]
+        public int CdrCorrelatorIndex { get; set; }
+        [XmlElement("callLegsActive")]
+        public int CallLegsActive { get; set; }
+        [XmlElement("callLegsMaxActive")]
+        public int CallLegsMaxActive { get; set; }
+        [XmlElement("callLegsCompleted")]
+        public int CallLegsCompleted { get; set; }
+        [XmlElement("audioBitRateOutgoing")]
+        public int AudioBitRateOutgoing { get; set; }
+        [XmlElement("audioBitRateIncoming")]
+        public int AudioBitRateIncoming { get; set; }
+        [XmlElement("videoBitRateOutgoing")]
+        public int VideoBitRateOutgoing { get; set; }
+        [XmlElement("videoBitRateIncoming")]
+        public int VideoBitRateIncoming { get; set; }
+    }
+}


### PR DESCRIPTION
Updated to facilitate getting data from the api/v1/system/{status|alarms|database} API endpoints, and added corresponding unit tests.

Modified CmsServer.cs and ICmsServer.cs to cater for the new SystemStatus class.